### PR TITLE
Fixing test: Count() is uint32

### DIFF
--- a/imt/tree_test.go
+++ b/imt/tree_test.go
@@ -81,7 +81,7 @@ func TestVectors(t *testing.T) {
 			}
 
 			// Make sure we've inserted the correct amount
-			require.Equal(t, i.Count(), len(c.Leaves))
+			require.Equal(t, int(i.Count()), len(c.Leaves))
 
 			// Make sure we've computed the expected root
 			expectedRoot, err := hex.DecodeString(c.ExpectedRoot[2:])


### PR DESCRIPTION
Fixes tests failing with:
```
--- FAIL: TestVectors (0.00s)
    --- FAIL: TestVectors/Testing_case:_three_leaves (0.00s)
        tree_test.go:84:
                Error Trace:    /home/jabbey/src/github.com/strangelove-ventures/hyperlane-cosmos/imt/tree_test.go:84
                Error:          Not equal:
                                expected: uint32(0x3)
                                actual  : int(3)
                Test:           TestVectors/Testing_case:_three_leaves
    --- FAIL: TestVectors/Testing_case:_one_leaf (0.00s)
        tree_test.go:84:
                Error Trace:    /home/jabbey/src/github.com/strangelove-ventures/hyperlane-cosmos/imt/tree_test.go:84
                Error:          Not equal:
                                expected: uint32(0x1)
                                actual  : int(1)
                Test:           TestVectors/Testing_case:_one_leaf
    --- FAIL: TestVectors/Testing_case:_no_leaves (0.00s)
        tree_test.go:84:
                Error Trace:    /home/jabbey/src/github.com/strangelove-ventures/hyperlane-cosmos/imt/tree_test.go:84
                Error:          Not equal:
                                expected: uint32(0x0)
                                actual  : int(0)
                Test:           TestVectors/Testing_case:_no_leaves
    --- FAIL: TestVectors/Testing_case:_forty-two_leaves (0.00s)
        tree_test.go:84:
                Error Trace:    /home/jabbey/src/github.com/strangelove-ventures/hyperlane-cosmos/imt/tree_test.go:84
                Error:          Not equal:
                                expected: uint32(0x2a)
                                actual  : int(42)
                Test:           TestVectors/Testing_case:_forty-two_leaves
    --- FAIL: TestVectors/Testing_case:_containing_empty_leaf (0.00s)
        tree_test.go:84:
                Error Trace:    /home/jabbey/src/github.com/strangelove-ventures/hyperlane-cosmos/imt/tree_test.go:84
                Error:          Not equal:
                                expected: uint32(0x5)
                                actual  : int(5)
                Test:           TestVectors/Testing_case:_containing_empty_leaf
FAIL
FAIL    github.com/strangelove-ventures/hyperlane-cosmos/imt    0.019s
```